### PR TITLE
Fixed the mmap function type hint.

### DIFF
--- a/src/nio/core.clj
+++ b/src/nio/core.clj
@@ -435,7 +435,7 @@
   only a portion of the file. Accepts keyword :mode option for the
   mapping mode. Valid options are: :read-write, :read-only, :private.
   Implemented for String, File and FileChannel."
-  ^MappedByteBuffer
+  ^java.nio.MappedByteBuffer
   [file & [offset length & {:as opts}]]
   (proto/do-mmap file offset length opts))
 

--- a/test/nio/test/core.clj
+++ b/test/nio/test/core.clj
@@ -129,6 +129,8 @@
   (let [m (mmap "test/foo.txt")]
     (is (= "foo.txt\n" (String. ^bytes (buffer-to-array m)
                                 "UTF-8"))))
+  (let [m (mmap "test/foo.txt")]
+    (is (= (.get m) 102)))
   (let [m (mmap (jio/file "test/foo.txt"))]
     (is (= "foo.txt\n" (String. ^bytes (buffer-to-array m)
                                 "UTF-8"))))


### PR DESCRIPTION
From MappedByteBuffer to java.nio.MappedByteBuffer. fixes #4
