### PR TITLE
Bugfix: add required third argument to clojure.java.io/do-copy

### DIFF
--- a/src/nio/core.clj
+++ b/src/nio/core.clj
@@ -118,7 +118,7 @@
  (fn [^File input ^File output opts]
    (with-open [input ^FileChannel (readable-channel input)
                output ^FileChannel (writable-channel output)]
-     (@#'jio/do-copy input output))))
+     (@#'jio/do-copy input output nil))))
 
 (prefer-method @#'jio/do-copy
                [FileChannel WritableByteChannel]

--- a/src/nio/core.clj
+++ b/src/nio/core.clj
@@ -118,7 +118,7 @@
  (fn [^File input ^File output opts]
    (with-open [input ^FileChannel (readable-channel input)
                output ^FileChannel (writable-channel output)]
-     (@#'jio/do-copy input output nil))))
+     (@#'jio/do-copy input output opts))))
 
 (prefer-method @#'jio/do-copy
                [FileChannel WritableByteChannel]


### PR DESCRIPTION
I randomly stumbled upon this error and was able to fix it locally by adding `nil` as the (optional) options hash.

This was the stacktrace I got:

```
             clojure.lang.ExceptionInfo: clojure.lang.ArityException: Wrong number of args (2) passed to: io/fn--9213/fn--9214
    data: {:file
           "/var/folders/h0/jb2j4f310zx08ynwfxw8lxg00000gn/T/boot.user5872914703740416115.clj",
           :line 25}
java.util.concurrent.ExecutionException: clojure.lang.ArityException: Wrong number of args (2) passed to: io/fn--9213/fn--9214
            clojure.lang.ArityException: Wrong number of args (2) passed to: io/fn--9213/fn--9214
                                ...
               nio.core/eval1511/fn    core.clj:  121
                                ...
               clojure.java.io/copy      io.clj:  396
                                ...
           boot.tmpdir/add-blob!/fn  tmpdir.clj:   59
              boot.tmpdir/add-blob!  tmpdir.clj:   59
         boot.tmpdir.TmpFileSet/add  tmpdir.clj:   89
          boot.core/add-user-source    core.clj:   91
            boot.core/reset-fileset    core.clj:  654
                                ...
                boot.core/run-tasks    core.clj:  694
                  boot.core/boot/fn    core.clj:  705
clojure.core/binding-conveyor-fn/fn    core.clj: 1916
```

ref: https://github.com/clojure/clojure/blob/cc69d19bd471c48d441071fff43e768ffa7eb8e5/src/clj/clojure/java/io.clj#L285-L290
